### PR TITLE
pd-mapper: Include limits.h for PATH_MAX

### DIFF
--- a/pd-mapper.c
+++ b/pd-mapper.c
@@ -36,6 +36,7 @@
 #include <fcntl.h>
 #include <libgen.h>
 #include <libqrtr.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Fixes
pd-mapper.c:199:22: error: 'PATH_MAX' undeclared (first use in this function); did you mean 'AF_MAX'?

Signed-off-by: Khem Raj <raj.khem@gmail.com>